### PR TITLE
feat: expand the definition with more examples

### DIFF
--- a/openapi/components/schemas/Admin.yaml
+++ b/openapi/components/schemas/Admin.yaml
@@ -1,0 +1,19 @@
+description: Example of user with admin permissions
+allOf:
+  - $ref: './User.yaml'
+  - type: object
+    properties:
+      adminDept:
+        type: string
+        description: Department which the admin user controls
+        default: all
+        example: finance
+        enum:
+          - all 
+          - finance
+          - hiring
+          - development
+          - support
+          - contractors
+    required:
+      - adminDept

--- a/openapi/components/schemas/Admin.yaml
+++ b/openapi/components/schemas/Admin.yaml
@@ -1,11 +1,16 @@
-description: Example of user with admin permissions
+description: "Example of a user profile with admin permissions. This type of user is also referred to as an **administrator**."
 allOf:
   - $ref: './User.yaml'
   - type: object
     properties:
+      userType:
+        type: string
+        enum:
+          - admin
+          - basic
       adminDept:
         type: string
-        description: Department which the admin user controls
+        description: "One or more departments which the admin user controls."
         default: all
         example: finance
         enum:
@@ -17,3 +22,4 @@ allOf:
           - contractors
     required:
       - adminDept
+      - userType

--- a/openapi/components/schemas/Basic.yaml
+++ b/openapi/components/schemas/Basic.yaml
@@ -1,14 +1,20 @@
-description: Example of user with basic permissions
+description: "Example of a user with basic (restricted) permissions. In total, there are 5 permission levels, but basic users can only use the first three."
 allOf:
   - $ref: './User.yaml'
   - type: object
     properties:
+      userType:
+        type: string
+        enum:
+          - admin
+          - basic
       permissionId:
         type: integer
         format: int32
-        description: Identifier of the permission level the basic user has
+        description: "Identifier of the permission level assigned to the basic user."
         default: 1
         minimum: 1
         maximum: 3
     required:
       - permissionId
+      - userType

--- a/openapi/components/schemas/Basic.yaml
+++ b/openapi/components/schemas/Basic.yaml
@@ -1,0 +1,14 @@
+description: Example of user with basic permissions
+allOf:
+  - $ref: './User.yaml'
+  - type: object
+    properties:
+      permissionId:
+        type: integer
+        format: int32
+        description: Identifier of the permission level the basic user has
+        default: 1
+        minimum: 1
+        maximum: 3
+    required:
+      - permissionId

--- a/openapi/components/schemas/Email.yaml
+++ b/openapi/components/schemas/Email.yaml
@@ -1,4 +1,4 @@
 description: "User's email address."
 type: string
-format: test
-example: 'bunny.rabbit@example.com'
+format: email
+example: bunny.rabbit@example.com

--- a/openapi/components/schemas/Email.yaml
+++ b/openapi/components/schemas/Email.yaml
@@ -1,4 +1,4 @@
-description: User email address
+description: "User's email address."
 type: string
 format: test
-example: john.smith@example.com
+example: 'bunny.rabbit@example.com'

--- a/openapi/components/schemas/ExampleObject.yaml
+++ b/openapi/components/schemas/ExampleObject.yaml
@@ -1,0 +1,19 @@
+type: object
+properties:
+  id:
+    description: "User ID."
+    allOf:
+      - $ref: './UserID.yaml'
+  name:
+    description: "Example name."
+    type: string
+    minLength: 1
+    maxLength: 64
+  container:
+    description: "Example object within an object."
+    type: object
+    properties:
+      number:
+        type: int32
+        description: "Example number value in a container object."
+        example: 22

--- a/openapi/components/schemas/ExampleObject.yaml
+++ b/openapi/components/schemas/ExampleObject.yaml
@@ -16,5 +16,6 @@ properties:
     properties:
       number:
         type: integer
-        description: "Example number value in a container object."
+        nullable: true
+        description: "Example nullable value in a container object."
         example: 22

--- a/openapi/components/schemas/ExampleObject.yaml
+++ b/openapi/components/schemas/ExampleObject.yaml
@@ -14,6 +14,6 @@ properties:
     type: object
     properties:
       number:
-        type: int32
+        type: integer
         description: "Example number value in a container object."
         example: 22

--- a/openapi/components/schemas/ExampleObject.yaml
+++ b/openapi/components/schemas/ExampleObject.yaml
@@ -9,6 +9,7 @@ properties:
     type: string
     minLength: 1
     maxLength: 64
+    example: BunnyRabbit
   container:
     description: "Example object within an object."
     type: object

--- a/openapi/components/schemas/ExampleObject.yaml
+++ b/openapi/components/schemas/ExampleObject.yaml
@@ -16,6 +16,5 @@ properties:
     properties:
       number:
         type: integer
-        nullable: true
         description: "Example nullable value in a container object."
         example: 22

--- a/openapi/components/schemas/User.yaml
+++ b/openapi/components/schemas/User.yaml
@@ -1,9 +1,17 @@
 type: object
+required:
+  - username
+discriminator:
+  propertyName: userType
+  mapping:
+    admin: ./Admin.yaml
+    basic: ./Basic.yaml
 properties:
   username:
     description: User supplied username
     type: string
     minLength: 4
+    maxLength: 64
     example: John78
   firstName:
     description: User first name
@@ -17,3 +25,32 @@ properties:
     example: Smith
   email:
     $ref: ./Email.yaml
+  userid:
+    description: ID of the user
+    externalDocs:
+      description: Example of external documentation link
+      url: 'https://example.com'
+    allOf:
+      - $ref: ./UserID.yaml
+  profileUrls:
+    description: The list of URLs to user social media profiles
+    type: array
+    maxItems: 10
+    xml:
+      name: profileUrl
+      wrapped: true
+    items:
+      type: string
+      format: url
+  status:
+    type: string
+    description: Status of the user account
+    enum:
+      - active
+      - banned
+      - inactive
+  userType:
+    description: Type of user account
+    type: string
+xml:
+  name: User

--- a/openapi/components/schemas/User.yaml
+++ b/openapi/components/schemas/User.yaml
@@ -1,6 +1,7 @@
 type: object
 required:
   - username
+  - status
 discriminator:
   propertyName: userType
   mapping:
@@ -8,32 +9,36 @@ discriminator:
     basic: ./Basic.yaml
 properties:
   username:
-    description: User supplied username
+    description: "The username associated with the user profile."
     type: string
     minLength: 4
-    maxLength: 64
-    example: John78
+    maxLength: 32
+    pattern: '/(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])/'
+    example: 'John78'
   firstName:
-    description: User first name
+    description: "User's first name."
     type: string
     minLength: 1
-    example: John
+    example: 'Bunny'
   lastName:
-    description: User last name
+    description: "User's last name."
     type: string
     minLength: 1
-    example: Smith
+    example: 'Rabbit'
   email:
-    $ref: ./Email.yaml
-  userid:
-    description: ID of the user
-    externalDocs:
-      description: Example of external documentation link
-      url: 'https://example.com'
+    $ref: './Email.yaml'
+  exampleObject:
+    description: "Example object to show an expanded schema."
     allOf:
-      - $ref: ./UserID.yaml
+      - $ref: './ExampleObject.yaml'
+  phone:
+    description: "User's phone number. Must be provided in international format."
+    type: string
+    pattern: '/^\+(?:[0-9]-?){6,14}[0-9]$/'
+    maxLength: 32
+    example: '+4-0800-555-0110'
   profileUrls:
-    description: The list of URLs to user social media profiles
+    description: "The list of URLs to user's social media profiles. You must provide the URLs with the scheme (`http or `https`)."
     type: array
     maxItems: 10
     xml:
@@ -42,15 +47,26 @@ properties:
     items:
       type: string
       format: url
+    example: ['https://twitter.com/example', 'https://instagram.com/example']
+  recursiveProperty:
+    allOf:
+      - $ref: './User.yaml'
   status:
-    type: string
-    description: Status of the user account
-    enum:
-      - active
-      - banned
-      - inactive
-  userType:
-    description: Type of user account
-    type: string
+    description: "Status of the user account."
+    type: array
+    minItems: 1
+    items:
+      type: string
+      enum:
+        - active
+        - banned
+        - inactive
+  userid:
+    description: "Unique ID of the user."
+    externalDocs:
+      description: Example of external documentation link
+      url: 'https://example.com'
+    allOf:
+      - $ref: './UserID.yaml'
 xml:
   name: User

--- a/openapi/components/schemas/User.yaml
+++ b/openapi/components/schemas/User.yaml
@@ -5,8 +5,8 @@ required:
 discriminator:
   propertyName: userType
   mapping:
-    admin: ./Admin.yaml
-    basic: ./Basic.yaml
+    admin: './Admin.yaml'
+    basic: './Basic.yaml'
 properties:
   username:
     description: "The username associated with the user profile."
@@ -14,17 +14,17 @@ properties:
     minLength: 4
     maxLength: 32
     pattern: '/(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])/'
-    example: 'John78'
+    example: John78
   firstName:
     description: "User's first name."
     type: string
     minLength: 1
-    example: 'Bunny'
+    example: Bunny
   lastName:
     description: "User's last name."
     type: string
     minLength: 1
-    example: 'Rabbit'
+    example: Rabbit
   email:
     $ref: './Email.yaml'
   exampleObject:
@@ -36,9 +36,9 @@ properties:
     type: string
     pattern: '/^\+(?:[0-9]-?){6,14}[0-9]$/'
     maxLength: 32
-    example: '+4-0800-555-0110'
+    example: +4-0800-555-0110
   profileUrls:
-    description: "The list of URLs to user's social media profiles. You must provide the URLs with the scheme (`http or `https`)."
+    description: "The list of URLs to user's social media profiles. You must provide the URLs with the scheme (`http` or `https`)."
     type: array
     maxItems: 10
     xml:

--- a/openapi/components/schemas/UserID.yaml
+++ b/openapi/components/schemas/UserID.yaml
@@ -1,0 +1,4 @@
+type: integer
+format: int64
+readOnly: true
+example: 27

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -72,7 +72,7 @@ servers:
   - url: https://example.com/api/v1
 paths:
   '/users/{username}':
-    $ref: 'paths/users@{username}.yaml'
+    $ref: 'paths/users_{username}.yaml'
   '/user':
     $ref: 'paths/user.yaml'
   '/user/list':

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -4,13 +4,15 @@ info:
   title: Example API
   termsOfService: https://example.com/terms/
   contact:
+    name: Contact our support
     email: contact@example.com
     url: http://example.com/contact
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   x-logo:
-    url: https://redocly.github.io/openapi-template/logo.png
+    url: 'https://redocly.github.io/openapi-template/logo.png'
+    altText: OpenAPI example logo
   description: >
     This is an **example** API to demonstrate features of the OpenAPI
     specification.
@@ -45,6 +47,19 @@ tags:
     description: Operations about users.
   - name: Tag
     description: This is a tag description.
+  - name: Admin
+    description: Operations reserved for administrators
+  - name: Info
+    description: Operations that retrieve information
+x-tagGroups:
+  - name: General
+    tags:
+      - User
+      - Info
+      - Echo
+  - name: Administration
+    tags:
+      - Admin
 servers:
   - url: https://{tenant}/api/v1
     variables:
@@ -53,17 +68,22 @@ servers:
         description: Your tenant id
   - url: https://example.com/api/v1
 paths:
-  /users/{username}:
-    $ref: paths/users_{username}.yaml
-  /echo:
-    $ref: paths/echo.yaml
+  '/users/{username}':
+    $ref: 'paths/users@{username}.yaml'
+  '/user':
+    $ref: 'paths/user.yaml'
+  '/user/status':
+    $ref: 'paths/user-status.yaml'
   /pathItem:
     $ref: paths/pathItem.yaml
   /pathItemWithExamples:
     $ref: paths/pathItemWithExamples.yaml
+  '/echo':
+    $ref: 'paths/echo.yaml'
 components:
   securitySchemes:
     main_auth:
+      description: "Example description text of the OAuth2 scheme."
       type: oauth2
       flows:
         implicit:
@@ -72,9 +92,26 @@ components:
             read:users: read users info
             write:users: modify or remove users
     api_key:
+      description: "Example description text of the API key scheme."
       type: apiKey
       in: header
       name: api_key
     basic_auth:
       type: http
       scheme: basic
+x-webhooks:
+  userInfo:
+    post:
+      summary: New user
+      description: Information about a new user in the system
+      operationId: userInfo
+      tags:
+        - Info
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'components/schemas/User.yaml'
+      responses:
+        '200':
+          description: "Information about a new user retrieved successfully."

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -40,17 +40,20 @@ info:
     implementation logic. Similar to what
     interfaces have done for lower-level programming, OpenAPI removes the
     guesswork in calling the service.
+externalDocs:
+  description: "Find out how to create a GitHub repo for your OpenAPI definition."
+  url: 'https://github.com/Redocly/create-openapi-repo'
 tags:
   - name: Echo
-    description: Example echo operations.
+    description: "Example echo operations."
   - name: User
-    description: Operations about users.
-  - name: Tag
-    description: This is a tag description.
+    description: "Example actions on user accounts."
   - name: Admin
-    description: Operations reserved for administrators
+    description: "Example operations reserved for administrators."
   - name: Info
-    description: Operations that retrieve information
+    description: "Example operations for retrieving information."
+  - name: Tag
+    description: "This is a tag description."
 x-tagGroups:
   - name: General
     tags:
@@ -72,7 +75,7 @@ paths:
     $ref: 'paths/users@{username}.yaml'
   '/user':
     $ref: 'paths/user.yaml'
-  '/user/status':
+  '/user/list':
     $ref: 'paths/user-status.yaml'
   /pathItem:
     $ref: paths/pathItem.yaml
@@ -89,8 +92,8 @@ components:
         implicit:
           authorizationUrl: http://example.com/api/oauth/dialog
           scopes:
-            read:users: read users info
-            write:users: modify or remove users
+            'read:users': read user info
+            'write:users': modify or remove users
     api_key:
       description: "Example description text of the API key scheme."
       type: apiKey
@@ -102,8 +105,8 @@ components:
 x-webhooks:
   userInfo:
     post:
-      summary: New user
-      description: Information about a new user in the system
+      summary: New user webhook
+      description: "Information about a new user in the system."
       operationId: userInfo
       tags:
         - Info
@@ -114,4 +117,4 @@ x-webhooks:
               $ref: 'components/schemas/User.yaml'
       responses:
         '200':
-          description: "Information about a new user retrieved successfully."
+          description: "Successfully retrieved information about a new user."

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -102,7 +102,7 @@ components:
     basic_auth:
       type: http
       scheme: basic
-x-webhooks:
+webhooks:
   userInfo:
     post:
       summary: New user webhook
@@ -118,3 +118,5 @@ x-webhooks:
       responses:
         '200':
           description: "Successfully retrieved information about a new user."
+      security:
+        - api_key: []

--- a/openapi/paths/echo.yaml
+++ b/openapi/paths/echo.yaml
@@ -2,7 +2,7 @@ post:
   tags:
     - Echo
   summary: Echo test
-  description: Receive the exact message you've sent
+  description: "This endpoint returns the exact message you've sent to it. You can use it for testing purposes."
   operationId: echo
   security:
     - api_key: []
@@ -12,7 +12,7 @@ post:
       description: OK
       headers:
         X-Rate-Limit:
-          description: calls per hour allowed by the user
+          description: "Calls per hour allowed by the user."
           schema:
             type: integer
             format: int32
@@ -24,10 +24,13 @@ post:
             type: string
           examples:
             response:
-              value: Hello world!
+              value: 'Hello world!'
         application/xml:
           schema:
             type: string
+          examples:
+            xml:
+              value: '<response>Hello world in XML!</response>'
         text/csv:
           schema:
             type: string
@@ -38,17 +41,17 @@ post:
       application/json:
         schema:
           type: string
-          example: Hello world!
+          example: 'Hello world!'
       application/xml:
         schema:
           type: string
-          example: Hello world!
-    description: Echo payload
+          example: 'Hello world in XML!'
+    description: "Example Echo payload. When the response is received, its contents should match the contents from the payload."
     required: true
   x-codeSamples:
     - lang: C#
       source:
-        $ref: ../code_samples/C_sharp/echo/post.cs
+        $ref: '../code_samples/csharp/echo/post.cs'
     - lang: PHP
       source:
-        $ref: ../code_samples/PHP/echo/post.php
+        $ref: '../code_samples/PHP/echo/post.php'

--- a/openapi/paths/echo.yaml
+++ b/openapi/paths/echo.yaml
@@ -51,7 +51,7 @@ post:
   x-codeSamples:
     - lang: C#
       source:
-        $ref: '../code_samples/csharp/echo/post.cs'
+        $ref: '../code_samples/C_sharp/echo/post.cs'
     - lang: PHP
       source:
         $ref: '../code_samples/PHP/echo/post.php'

--- a/openapi/paths/user-status.yaml
+++ b/openapi/paths/user-status.yaml
@@ -1,17 +1,19 @@
 get:
   tags:
     - Admin
-  summary: Find users by status
-  description: "Multiple status values can be provided with comma-separated strings. Only administrators can use this endpoint."
+  summary: List users by status
+  description: "This operation lets you list users by their status. Multiple status values can be provided in a single request by using comma-separated strings. Only administrators can use this operation."
   operationId: userStatus
   parameters:
     - name: status
       in: query
-      description: User status values by which to look up user accounts.
+      description: "One or more user status values by which to look up user accounts."
       required: true
       style: form
+      explode: false
       schema:
         type: array
+        uniqueItems: true
         minItems: 1
         maxItems: 3
         items:
@@ -35,6 +37,10 @@ get:
             type: array
             items:
               $ref: '../components/schemas/User.yaml'
+        text/plain:
+          examples:
+            response:
+              value: Success!
     '400':
       description: Invalid status value was provided in the request
   security:

--- a/openapi/paths/user-status.yaml
+++ b/openapi/paths/user-status.yaml
@@ -1,0 +1,43 @@
+get:
+  tags:
+    - Admin
+  summary: Find users by status
+  description: "Multiple status values can be provided with comma-separated strings. Only administrators can use this endpoint."
+  operationId: userStatus
+  parameters:
+    - name: status
+      in: query
+      description: User status values by which to look up user accounts.
+      required: true
+      style: form
+      schema:
+        type: array
+        minItems: 1
+        maxItems: 3
+        items:
+          type: string
+          enum:
+            - active
+            - banned
+            - inactive
+          default: active         
+  responses:
+    '200':
+      description: Successful response example
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '../components/schemas/User.yaml'
+          application/xml:
+            schema:
+              type: array
+              items:
+                $ref: '../components/schemas/User.yaml'
+    '400':
+      description: Invalid status value was provided in the request
+  security:
+    - main_auth:
+        - 'read:users'
+        - 'write:users'

--- a/openapi/paths/user-status.yaml
+++ b/openapi/paths/user-status.yaml
@@ -24,17 +24,17 @@ get:
   responses:
     '200':
       description: Successful response example
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '../components/schemas/User.yaml'
-          application/xml:
-            schema:
-              type: array
-              items:
-                $ref: '../components/schemas/User.yaml'
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../components/schemas/User.yaml'
+        application/xml:
+          schema:
+            type: array
+            items:
+              $ref: '../components/schemas/User.yaml'
     '400':
       description: Invalid status value was provided in the request
   security:

--- a/openapi/paths/user-status.yaml
+++ b/openapi/paths/user-status.yaml
@@ -2,8 +2,9 @@ get:
   tags:
     - Admin
   summary: List users by status
-  description: "This operation lets you list users by their status. Multiple status values can be provided in a single request by using comma-separated strings. Only administrators can use this operation."
+  description: "This operation lets you list users by their status. Multiple status values can be provided in a single request by using comma-separated strings. Only administrators can use this operation.\n \n**This is an example of a deprecated operation.**"
   operationId: userStatus
+  deprecated: true
   parameters:
     - name: status
       in: query

--- a/openapi/paths/user.yaml
+++ b/openapi/paths/user.yaml
@@ -43,8 +43,8 @@ post:
           schema:
             type: object
             properties:
-                name: User
-                type: string
-                description: Example description
+                name: 
+                  type: string
+                  description: Example description
     description: User record to be added to the database
     required: true

--- a/openapi/paths/user.yaml
+++ b/openapi/paths/user.yaml
@@ -46,5 +46,5 @@ post:
                 name: User
                 type: string
                 description: Example description
-      description: User record to be added to the database
-      required: true
+    description: User record to be added to the database
+    required: true

--- a/openapi/paths/user.yaml
+++ b/openapi/paths/user.yaml
@@ -36,8 +36,8 @@ post:
             discriminator:
               propertyName: userType
               mapping:
-                admin: ./Admin.yaml
-                basic: ./Basic.yaml
+                admin: '../components/schemas/Admin.yaml'
+                basic: '../components/schemas/Basic.yaml'
             anyOf:
               - $ref: '../components/schemas/Admin.yaml'
               - $ref: '../components/schemas/Basic.yaml'

--- a/openapi/paths/user.yaml
+++ b/openapi/paths/user.yaml
@@ -1,17 +1,15 @@
 parameters:
   - name: Accept-Language
     in: header
-    description: >-
-        The language you prefer for messages. Supported values are en-AU,
-        en-CA, en-GB, en-US
+    description: "The language you prefer for messages. Supported values are `en-AU, en-CA, en-GB, en-US`."
     example: en-US
     required: false
     schema:
         type: string
-        default: en-AU
+        default: en-GB
   - name: cookieParam
     in: cookie
-    description: Some cookie
+    description: "Example cookie parameter."
     required: true
     schema:
         type: integer
@@ -20,7 +18,7 @@ post:
   tags:
     - Admin
   summary: Create a new user
-  description: This can only be done by an administrator.
+  description: "This operation creates a new user profile. Only administrators can create user profiles."
   operationId: createUser
   responses:
     '200':
@@ -35,10 +33,14 @@ post:
     content:
         application/json:
           schema:
-            allOf:
-              - description: New user
-                title: UserRecord
-              - $ref: '../components/schemas/User.yaml'
+            discriminator:
+              propertyName: userType
+              mapping:
+                admin: ./Admin.yaml
+                basic: ./Basic.yaml
+            anyOf:
+              - $ref: '../components/schemas/Admin.yaml'
+              - $ref: '../components/schemas/Basic.yaml'
         application/xml:
           schema:
             type: object
@@ -46,5 +48,5 @@ post:
                 name: 
                   type: string
                   description: Example description
-    description: User record to be added to the database
+    description: "User profile to be added to the database."
     required: true

--- a/openapi/paths/user.yaml
+++ b/openapi/paths/user.yaml
@@ -23,6 +23,8 @@ post:
   description: This can only be done by an administrator.
   operationId: createUser
   responses:
+    '200':
+      description: Successfully created a user
     '405':
       description: Invalid input
   security:
@@ -30,8 +32,7 @@ post:
         - 'read:users'
         - 'write:users'
   requestBody:
-    User:
-      content:
+    content:
         application/json:
           schema:
             allOf:

--- a/openapi/paths/user.yaml
+++ b/openapi/paths/user.yaml
@@ -1,0 +1,49 @@
+parameters:
+  - name: Accept-Language
+    in: header
+    description: >-
+        The language you prefer for messages. Supported values are en-AU,
+        en-CA, en-GB, en-US
+    example: en-US
+    required: false
+    schema:
+        type: string
+        default: en-AU
+  - name: cookieParam
+    in: cookie
+    description: Some cookie
+    required: true
+    schema:
+        type: integer
+        format: int64
+post:
+  tags:
+    - Admin
+  summary: Create a new user
+  description: This can only be done by an administrator.
+  operationId: createUser
+  responses:
+    '405':
+      description: Invalid input
+  security:
+    - main_auth:
+        - 'read:users'
+        - 'write:users'
+  requestBody:
+    User:
+      content:
+        application/json:
+          schema:
+            allOf:
+              - description: New user
+                title: UserRecord
+              - $ref: '../components/schemas/User.yaml'
+        application/xml:
+          schema:
+            type: object
+            properties:
+                name: User
+                type: string
+                description: Example description
+      description: User record to be added to the database
+      required: true

--- a/openapi/paths/users_{username}.yaml
+++ b/openapi/paths/users_{username}.yaml
@@ -71,35 +71,6 @@ put:
   security:
     - main_auth:
         - 'write:users'
-  responses:
-    '200':
-      description: Successfully updated the user profile
-      content:
-        application/json:
-          example:
-            status: 200
-            message: OK
-    '400':
-      description: Invalid username supplied
-      content:
-        application/json:
-          example:
-            status: 400
-            message: Invalid username
-    '404':
-      description: User not found
-      content:
-        application/json:
-          example:
-            status: 404
-            message: Not found
-    '405':
-      description: Method not allowed
-      content:
-        application/json:
-          example:
-            status: 405
-            message: Not allowed
   requestBody:
     content:
       application/json:
@@ -112,13 +83,25 @@ put:
     required: true
   responses:
     '200':
-      description: OK
+      description: Successfully updated the user profile
+      content:
+        application/json:
+          example:
+            status: 200
+            message: OK
     '400':
-      description: Invalid user supplied
+      description: Invalid username supplied
       $ref: ../components/responses/Problem.yaml
     '404':
       description: User not found
       $ref: ../components/responses/Problem.yaml
+    '405':
+      description: Method not allowed
+      content:
+        application/json:
+          example:
+            status: 405
+            message: Not allowed
 delete:
   tags:
     - Admin

--- a/openapi/paths/users_{username}.yaml
+++ b/openapi/paths/users_{username}.yaml
@@ -1,32 +1,34 @@
 parameters:
   - name: pretty_print
     in: query
-    description: Pretty print response.
+    description: "Choose whether to pretty print the response. This option is **disabled** by default."
     schema:
       type: boolean
+      default: false
 get:
   tags:
     - User
-  summary: Get user by user name
+  summary: Get user by name
   description: |
-    Some description of the operation.
-    You can use `Markdown` here.
+    Example description of the operation.
+    You can use `markdown` **here**.
   operationId: getUserByName
   parameters:
     - name: username
       in: path
-      description: The name that needs to be fetched.
+      description: "The username for which you want to retrieve the data."
       required: true
       schema:
         type: string
     - name: with_email
       in: query
-      description: Filter users without email.
+      description: "Use this parameter to filter users without email. By default, only users with email are displayed."
       schema:
         type: boolean
+        default: true
     - name: userid
       in: query
-      description: ID of the user. This is an example of a deprecated parameter.
+      description: "ID of the user. This is an example of a **deprecated** parameter."
       required: false
       deprecated: true
       schema:
@@ -42,10 +44,10 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/User.yaml
+            $ref: '../components/schemas/User.yaml'
           example:
-            username: user1
-            email: user@example.com
+            username: 'user1'
+            email: 'user@example.com'
     '403':
       description: Forbidden
       $ref: ../components/responses/Problem.yaml
@@ -55,27 +57,56 @@ get:
 put:
   tags:
     - User
-  summary: Updated user
-  description: This can only be done by the logged in user.
+  summary: Update user data
+  description: "This operation allows users to update the information in their own profile. The update can only be performed by the logged in user."
   operationId: updateUser
   parameters:
     - name: username
       in: path
-      description: The name that needs to be updated.
+      description: "The name of the user profile to be **updated**."
       required: true
       schema:
         type: string
   security:
     - main_auth:
         - 'write:users'
+  responses:
+    '200':
+      description: Successfully updated the user profile
+      content:
+        application/json:
+          example:
+            status: 200
+            message: OK
+    '400':
+      description: Invalid username supplied
+      content:
+        application/json:
+          example:
+            status: 400
+            message: Invalid username
+    '404':
+      description: User not found
+      content:
+        application/json:
+          example:
+            status: 404
+            message: Not found
+    '405':
+      description: Method not allowed
+      content:
+        application/json:
+          example:
+            status: 405
+            message: Not allowed
   requestBody:
     content:
       application/json:
         schema:
-          $ref: ../components/schemas/User.yaml
+          $ref: '../components/schemas/User.yaml'
       application/xml:
         schema:
-          $ref: ../components/schemas/User.yaml
+          $ref: '../components/schemas/User.yaml'
     description: Updated user object
     required: true
   responses:
@@ -90,8 +121,8 @@ put:
 delete:
   tags:
     - Admin
-  summary: Deletes a user
-  description: This can only be done by an administrator.
+  summary: Delete a user
+  description: "This operation deletes all data associated with the requested `username`. Only administrators can perform this operation."
   operationId: deleteUser
   parameters:
     - name: api_key
@@ -99,10 +130,10 @@ delete:
       required: false
       schema:
         type: string
-        example: Bearer <TOKEN>
+        example: 'Bearer <TOKEN>'
     - name: username
       in: path
-      description: Name of the user to delete.
+      description: "The name of the user profile to be **deleted**."
       required: true
       schema:
         type: string

--- a/openapi/paths/users_{username}.yaml
+++ b/openapi/paths/users_{username}.yaml
@@ -17,6 +17,7 @@ get:
     - name: username
       in: path
       description: "The username for which you want to retrieve the data."
+      example: John78
       required: true
       schema:
         type: string
@@ -134,6 +135,7 @@ delete:
     - name: username
       in: path
       description: "The name of the user profile to be **deleted**."
+      example: John78
       required: true
       schema:
         type: string

--- a/openapi/paths/users_{username}.yaml
+++ b/openapi/paths/users_{username}.yaml
@@ -1,7 +1,7 @@
 parameters:
   - name: pretty_print
     in: query
-    description: Pretty print response
+    description: Pretty print response.
     schema:
       type: boolean
 get:
@@ -15,15 +15,23 @@ get:
   parameters:
     - name: username
       in: path
-      description: The name that needs to be fetched
+      description: The name that needs to be fetched.
       required: true
       schema:
         type: string
     - name: with_email
       in: query
-      description: Filter users without email
+      description: Filter users without email.
       schema:
         type: boolean
+    - name: userid
+      in: path
+      description: ID of the user. This is an example of a deprecated parameter.
+      required: true
+      deprecated: true
+      schema:
+        type: integer
+        format: int64
   security:
     - main_auth:
         - read:users
@@ -53,13 +61,13 @@ put:
   parameters:
     - name: username
       in: path
-      description: The name that needs to be updated
+      description: The name that needs to be updated.
       required: true
       schema:
         type: string
   security:
     - main_auth:
-        - write:users
+        - 'write:users'
   requestBody:
     content:
       application/json:
@@ -79,3 +87,32 @@ put:
     '404':
       description: User not found
       $ref: ../components/responses/Problem.yaml
+delete:
+  tags:
+    - Admin
+  summary: Deletes a user
+  description: This can only be done by an administrator.
+  operationId: deleteUser
+  parameters:
+    - name: api_key
+      in: header
+      required: false
+      schema:
+        type: string
+        example: Bearer <TOKEN>
+    - name: username
+      in: path
+      description: Name of the user to delete.
+      required: true
+      schema:
+        type: string
+  responses:
+    '400':
+      description: Invalid username provided
+    '404':
+      description: User not found
+  security:
+    - main_auth:
+        - 'read:users'
+        - 'write:users'
+    - api_key: []

--- a/openapi/paths/users_{username}.yaml
+++ b/openapi/paths/users_{username}.yaml
@@ -25,9 +25,9 @@ get:
       schema:
         type: boolean
     - name: userid
-      in: path
+      in: query
       description: ID of the user. This is an example of a deprecated parameter.
-      required: true
+      required: false
       deprecated: true
       schema:
         type: integer
@@ -107,6 +107,8 @@ delete:
       schema:
         type: string
   responses:
+    '200':
+      description: Successfully deleted a user
     '400':
       description: Invalid username provided
     '404':

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -6,6 +6,7 @@ extends:
   - recommended
 rules:
   no-unused-components: error
+  no-server-example.com: off
 theme:
   openapi:
     htmlTemplate: ./docs/index.html


### PR DESCRIPTION
Added examples for:

- discriminator usage
- deprecated parameter and operation
- x-tagGroups
- x-webhooks
- `delete` and `post` operations
- `nullable`
- recursive property
- object within object

To add:

- callback
- examples for content type x-www-form-encoded and octet-stream
- oneOf example
- XML schemas
- x-traitTag and x-summary usage examples
- better response examples 