### PR TITLE
docs: remove externalDocs from starter

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -13,9 +13,6 @@ info:
     url: 'https://redocly.github.io/openapi-template/logo.png'
   description:
     $ref: ./info-description.md
-externalDocs:
-  description: Find out how to create a GitHub repo for your OpenAPI definition.
-  url: 'https://github.com/Rebilly/generator-openapi-repo'
 tags:
   - name: Echo
     description: Example echo operations.


### PR DESCRIPTION
- removed because it is rarely called for when using an info description


## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
