### PR TITLE
Update .redocly.yaml

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -5,7 +5,7 @@ lint:
   extends:
     - recommended
   rules:
-    no-unused-components: warning
+    no-unused-components: warn
 referenceDocs:
   htmlTemplate: ./docs/index.html
   theme:


### PR DESCRIPTION
## What/Why/How?
Incorrect value for `severity`, it should be `warn` instead of `warning` according to [docs](https://redoc.ly/docs/cli/guides/lint/#severity-levels)
## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
