### PR TITLE
chore: switch to a new package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "acme-api",
       "version": "1.0.0",
       "dependencies": {
-        "@redocly/openapi-cli": "1.0.0-beta.89"
+        "@redocly/cli": "1.0.0-beta.96"
       }
     },
     "node_modules/@redocly/ajv": {
@@ -26,12 +26,12 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@redocly/openapi-cli": {
-      "version": "1.0.0-beta.89",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-cli/-/openapi-cli-1.0.0-beta.89.tgz",
-      "integrity": "sha512-kQxBdHKKVOaV3jfWMTsqlgvDAidm31wG5dD6DifDKZphQWqZam1gHXRMnF1mWyN4V9U4xza1cP3KIzCwb7vd1Q==",
+    "node_modules/@redocly/cli": {
+      "version": "1.0.0-beta.96",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.0.0-beta.96.tgz",
+      "integrity": "sha512-i+PMErLrR0KR1BYnLxm9TCSts9oQGbLQupmCkZ5K/JgXCtktd0ghOjU1pa80tNx3GwPcWFrOStW3UAFfuk16dg==",
       "dependencies": {
-        "@redocly/openapi-core": "1.0.0-beta.89",
+        "@redocly/openapi-core": "1.0.0-beta.96",
         "@types/node": "^14.11.8",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
@@ -44,16 +44,17 @@
         "yargs": "17.0.1"
       },
       "bin": {
-        "openapi": "bin/cli.js"
+        "openapi": "bin/cli.js",
+        "redocly": "bin/cli.js"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@redocly/openapi-core": {
-      "version": "1.0.0-beta.89",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.89.tgz",
-      "integrity": "sha512-3+k9oIBhCcs7LJ50eCWB6FdwV4pDH06d613pwFo5F2TmDPviNVWothj3CO/BheDz24tc9K8xR5pQuECE65qr/w==",
+    "node_modules/@redocly/cli/node_modules/@redocly/openapi-core": {
+      "version": "1.0.0-beta.96",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.96.tgz",
+      "integrity": "sha512-tcy0q+9PRWV4rcnVx5uHII/9Cq9qpUzWNppupAaVgutxjQRPWH45e24NLinn6lA8Q4por6HuMYkk/0QAJE8d3A==",
       "dependencies": {
         "@redocly/ajv": "^8.6.4",
         "@types/node": "^14.11.8",
@@ -850,12 +851,12 @@
         "uri-js": "^4.2.2"
       }
     },
-    "@redocly/openapi-cli": {
-      "version": "1.0.0-beta.89",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-cli/-/openapi-cli-1.0.0-beta.89.tgz",
-      "integrity": "sha512-kQxBdHKKVOaV3jfWMTsqlgvDAidm31wG5dD6DifDKZphQWqZam1gHXRMnF1mWyN4V9U4xza1cP3KIzCwb7vd1Q==",
+    "@redocly/cli": {
+      "version": "1.0.0-beta.96",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-1.0.0-beta.96.tgz",
+      "integrity": "sha512-i+PMErLrR0KR1BYnLxm9TCSts9oQGbLQupmCkZ5K/JgXCtktd0ghOjU1pa80tNx3GwPcWFrOStW3UAFfuk16dg==",
       "requires": {
-        "@redocly/openapi-core": "1.0.0-beta.89",
+        "@redocly/openapi-core": "1.0.0-beta.96",
         "@types/node": "^14.11.8",
         "assert-node-version": "^1.0.3",
         "chokidar": "^3.5.1",
@@ -866,23 +867,25 @@
         "portfinder": "^1.0.26",
         "simple-websocket": "^9.0.0",
         "yargs": "17.0.1"
-      }
-    },
-    "@redocly/openapi-core": {
-      "version": "1.0.0-beta.89",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.89.tgz",
-      "integrity": "sha512-3+k9oIBhCcs7LJ50eCWB6FdwV4pDH06d613pwFo5F2TmDPviNVWothj3CO/BheDz24tc9K8xR5pQuECE65qr/w==",
-      "requires": {
-        "@redocly/ajv": "^8.6.4",
-        "@types/node": "^14.11.8",
-        "colorette": "^1.2.0",
-        "js-levenshtein": "^1.1.6",
-        "js-yaml": "^4.1.0",
-        "lodash.isequal": "^4.5.0",
-        "minimatch": "^3.0.4",
-        "node-fetch": "^2.6.1",
-        "pluralize": "^8.0.0",
-        "yaml-ast-parser": "0.0.43"
+      },
+      "dependencies": {
+        "@redocly/openapi-core": {
+          "version": "1.0.0-beta.96",
+          "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.0.0-beta.96.tgz",
+          "integrity": "sha512-tcy0q+9PRWV4rcnVx5uHII/9Cq9qpUzWNppupAaVgutxjQRPWH45e24NLinn6lA8Q4por6HuMYkk/0QAJE8d3A==",
+          "requires": {
+            "@redocly/ajv": "^8.6.4",
+            "@types/node": "^14.11.8",
+            "colorette": "^1.2.0",
+            "js-levenshtein": "^1.1.6",
+            "js-yaml": "^4.1.0",
+            "lodash.isequal": "^4.5.0",
+            "minimatch": "^3.0.4",
+            "node-fetch": "^2.6.1",
+            "pluralize": "^8.0.0",
+            "yaml-ast-parser": "0.0.43"
+          }
+        }
       }
     },
     "@types/glob": {

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "acme-api",
   "version": "1.0.0",
   "dependencies": {
-    "@redocly/openapi-cli": "1.0.0-beta.89"
+    "@redocly/cli": "1.0.0-beta.96"
   },
   "private": true,
   "scripts": {
-    "start": "openapi preview-docs",
-    "build": "openapi bundle -o dist",
-    "test": "openapi lint"
+    "start": "redocly preview-docs",
+    "build": "redocly bundle -o dist",
+    "test": "redocly lint"
   }
 }


### PR DESCRIPTION
## What/Why/How?

We renamed `@redocly/openapi-cli` to `@redocly/cli`, more details here: https://github.com/Redocly/redocly-cli/pull/672

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
