### PR TITLE
fix: null type should be a string

### DIFF
--- a/openapi/components/schemas/Schema.yaml
+++ b/openapi/components/schemas/Schema.yaml
@@ -42,7 +42,7 @@ properties:
     description: Property name's description (type is string or null)
     type:
       - string
-      - null
+      - "null"
     examples:
       - example
   stringEnumValues:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -26,9 +26,6 @@ servers:
       tenant:
         default: www
         description: Your tenant id
-        enum:
-          - 4e6b7b2f-f051-4ddd-8340-d664f1b12777.remockly.com
-          - www
   - url: 'https://example.com/api/v1'
 paths:
   '/users/{username}':

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -26,6 +26,9 @@ servers:
       tenant:
         default: www
         description: Your tenant id
+        enum:
+          - 4e6b7b2f-f051-4ddd-8340-d664f1b12777.remockly.com
+          - www
   - url: 'https://example.com/api/v1'
 paths:
   '/users/{username}':


### PR DESCRIPTION
## What/Why/How?

The YAML parser parses `null` as a null value instead of as `"null"` the string. 
