### PR TITLE
chore: output bundled files as dist/bundle.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "start": "redocly preview-docs",
-    "build": "redocly bundle -o dist",
+    "build": "redocly bundle -o dist/bundle.yaml",
     "test": "redocly lint"
   }
 }


### PR DESCRIPTION
## What/Why/How?
In the README, 'npm run build' bundles the definition to the dist folder.
However before the modification, the script outputed 'dist.yaml' in the root directory.
Therefore, 'dist.yaml' was marked as unmanaged by git.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
