### PR TITLE
Update links containing outdated "master" branch to "main"

### DIFF
--- a/openapi/code_samples/README.md
+++ b/openapi/code_samples/README.md
@@ -5,7 +5,7 @@ This is our recommended convention for organizing `code_samples`:
 
 [x-codeSamples](https://redocly.com/docs/api-reference-docs/specification-extensions/x-code-samples/)
 Path `<lang>/<path>/<HTTP verb>.<extension>` where:
-  * `<lang>` - name of the language from [this](https://github.com/github/linguist/blob/master/lib/linguist/popular.yml) list.
+  * `<lang>` - name of the language from [this](https://github.com/github-linguist/linguist/blob/master/lib/linguist/popular.yml) list.
   * `<path>` - path of the target method, where all `/` are replaced with `_`.
   * `<HTTP verb>` - verb of target method.
   * `<extension>` - ignored.

--- a/openapi/components/README.md
+++ b/openapi/components/README.md
@@ -1,13 +1,13 @@
 # Reusable components
 
 * You can create the following folders here:
-  - `schemas` - reusable [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject)
-  - `responses` - reusable [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#responseObject)
-  - `parameters` - reusable [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject)
-  - `examples` - reusable [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#exampleObject)
-  - `headers` - reusable [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#headerObject)
-  - `requestBodies` - reusable [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#requestBodyObject)
-  - `links` - reusable [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#linkObject)
-  - `callbacks` - reusable [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#callbackObject)
-  - `securitySchemes` - reusable [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#securitySchemeObject)
+  - `schemas` - reusable [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#schemaObject)
+  - `responses` - reusable [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#responseObject)
+  - `parameters` - reusable [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#parameterObject)
+  - `examples` - reusable [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#exampleObject)
+  - `headers` - reusable [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#headerObject)
+  - `requestBodies` - reusable [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#requestBodyObject)
+  - `links` - reusable [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#linkObject)
+  - `callbacks` - reusable [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#callbackObject)
+  - `securitySchemes` - reusable [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#securitySchemeObject)
 * Filename of files inside the folders represent component name, e.g. `Customer.yaml`

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -19,13 +19,13 @@ info:
 
     This API definition is intended to to be a good starting point for
     describing your API in [OpenAPI/Swagger
-    format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md).
+    format](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md).
 
     It also demonstrates features of the
     [create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool
     and the [Redoc](https://github.com/Redocly/Redoc) documentation engine. Beyond
     the standard OpenAPI syntax, we use a few 
-    [vendor extensions](https://github.com/Redocly/Redoc/blob/master/docs/redoc-vendor-extensions.md).
+    [vendor extensions](https://github.com/Redocly/Redoc/blob/main/docs/redoc-vendor-extensions.md).
 
     # OpenAPI Specification
 


### PR DESCRIPTION
Addresses issue: https://github.com/Redocly/openapi-starter/issues/114

**Motivation**
This repo changed its root branch from `master` to `main`, but there are still links in this repo that point to the old `master` branch. These links are broken, as the website does the correct redirect to the assets, but it's an easy fix to update:
https://github.com/search?q=repo%3ARedocly%2Fopenapi-starter%20master&type=code

**Changes Made**
BEFORE: `https://github.com/OAI/OpenAPI-Specification/blob/master/...`
AFTER: `https://github.com/OAI/OpenAPI-Specification/blob/main/...`

BEFORE: https://github.com/Redocly/Redoc/blob/master/docs/redoc-vendor-extensions.md
AFTER: https://github.com/Redocly/Redoc/blob/main/docs/redoc-vendor-extensions.md

_github/linguist got renamed to github-linguist/linguist but have not yet updated their base branch name_
BEFORE: https://github.com/github/linguist/blob/master/lib/linguist/popular.yml
AFTER: https://github.com/github-linguist/linguist/blob/master/lib/linguist/popular.yml
