### PR TITLE
Update documentation links from referencing 3.0.2 to 3.1.0

### DIFF
--- a/openapi/components/README.md
+++ b/openapi/components/README.md
@@ -1,13 +1,13 @@
 # Reusable components
 
 * You can create the following folders here:
-  - `schemas` - reusable [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#schemaObject)
-  - `responses` - reusable [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#responseObject)
-  - `parameters` - reusable [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#parameterObject)
-  - `examples` - reusable [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#exampleObject)
-  - `headers` - reusable [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#headerObject)
-  - `requestBodies` - reusable [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#requestBodyObject)
-  - `links` - reusable [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#linkObject)
-  - `callbacks` - reusable [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#callbackObject)
-  - `securitySchemes` - reusable [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#securitySchemeObject)
+  - `schemas` - reusable [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject)
+  - `responses` - reusable [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#responseObject)
+  - `parameters` - reusable [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameterObject)
+  - `examples` - reusable [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#exampleObject)
+  - `headers` - reusable [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#headerObject)
+  - `requestBodies` - reusable [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#requestBodyObject)
+  - `links` - reusable [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#linkObject)
+  - `callbacks` - reusable [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callbackObject)
+  - `securitySchemes` - reusable [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#securitySchemeObject)
 * Filename of files inside the folders represent component name, e.g. `Customer.yaml`

--- a/openapi/components/README.md
+++ b/openapi/components/README.md
@@ -1,13 +1,13 @@
 # Reusable components
 
 * You can create the following folders here:
-  - `schemas` - reusable [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject)
-  - `responses` - reusable [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#responseObject)
-  - `parameters` - reusable [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameterObject)
-  - `examples` - reusable [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#exampleObject)
-  - `headers` - reusable [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#headerObject)
-  - `requestBodies` - reusable [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#requestBodyObject)
-  - `links` - reusable [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#linkObject)
-  - `callbacks` - reusable [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callbackObject)
-  - `securitySchemes` - reusable [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#securitySchemeObject)
+  - `schemas` - reusable [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object)
+  - `responses` - reusable [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#response-object)
+  - `parameters` - reusable [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object)
+  - `examples` - reusable [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#example-object)
+  - `headers` - reusable [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#header-object)
+  - `requestBodies` - reusable [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#request-body-object)
+  - `links` - reusable [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#link-object)
+  - `callbacks` - reusable [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callback-object)
+  - `securitySchemes` - reusable [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-scheme-object)
 * Filename of files inside the folders represent component name, e.g. `Customer.yaml`

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -19,7 +19,7 @@ info:
 
     This API definition is intended to to be a good starting point for
     describing your API in [OpenAPI/Swagger
-    format](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md).
+    format](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md).
 
     It also demonstrates features of the
     [create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool

--- a/openapi/paths/README.md
+++ b/openapi/paths/README.md
@@ -31,7 +31,7 @@ In addition, Redocly recommends placing path parameters within `{}` curly braces
 
 * Quickly see a list of all paths.  Many people think in terms of the "number" of "endpoints" (paths), and not the "number" of "operations" (paths * http methods).
 
-* Only the "file-per-path" option is semantically correct with the OpenAPI Specification 3.0.2.  However, Redocly's openapi-cli will build valid bundles for any of the other options too.
+* Only the "file-per-path" option is semantically correct with the OpenAPI Specification 3.1.0.  However, Redocly's openapi-cli will build valid bundles for any of the other options too.
 
 
 #### Drawbacks


### PR DESCRIPTION
## What/Why/How?
The base spec in this repo was already updated to 3.1.0: https://github.com/Redocly/openapi-starter/blob/2bd7622691d5e2ccd0b346c2871cdadf2e5c5e00/openapi/openapi.yaml#L1

The results of `npm test` already validate that this is a correctly formed 3.1.0 spec (the only flag is on the server URL being `example.com`). These links just needed to be updated to accurately reflect the version available in this template repo. The headers on those links also needed to be updated to what the new spec has them listed as.

Here are all the new links:
- https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md
- [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object)
- [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#response-object)
- [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object)
- [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#example-object)
- [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#header-object)
- [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#request-body-object)
- [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#link-object)
- [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callback-object)
- [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-scheme-object)

## Reference
https://github.com/Redocly/openapi-starter/issues/116

## Testing
These changes are just updates to links in Markdown files.
