### PR TITLE
Update OpenAPI 3.1 documentation links

### DIFF
--- a/openapi/components/README.md
+++ b/openapi/components/README.md
@@ -1,13 +1,13 @@
 # Reusable components
 
 * You can create the following folders here:
-  - `schemas` - reusable [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#schemaObject)
-  - `responses` - reusable [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#responseObject)
-  - `parameters` - reusable [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#parameterObject)
-  - `examples` - reusable [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#exampleObject)
-  - `headers` - reusable [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#headerObject)
-  - `requestBodies` - reusable [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#requestBodyObject)
-  - `links` - reusable [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#linkObject)
-  - `callbacks` - reusable [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#callbackObject)
-  - `securitySchemes` - reusable [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#securitySchemeObject)
+  - `schemas` - reusable [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object)
+  - `responses` - reusable [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#response-object)
+  - `parameters` - reusable [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object)
+  - `examples` - reusable [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#example-object)
+  - `headers` - reusable [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#header-object)
+  - `requestBodies` - reusable [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#request-body-object)
+  - `links` - reusable [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#link-object)
+  - `callbacks` - reusable [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#callback-object)
+  - `securitySchemes` - reusable [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#security-scheme-object)
 * Filename of files inside the folders represent component name, e.g. `Customer.yaml`

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -21,7 +21,7 @@ info:
 
     This API definition is intended to to be a good starting point for
     describing your API in [OpenAPI/Swagger
-    format](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md).
+    format](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md).
 
     It also demonstrates features of the
     [create-openapi-repo](https://github.com/Redocly/create-openapi-repo) tool

--- a/openapi/paths/README.md
+++ b/openapi/paths/README.md
@@ -31,7 +31,7 @@ In addition, Redocly recommends placing path parameters within `{}` curly braces
 
 * Quickly see a list of all paths.  Many people think in terms of the "number" of "endpoints" (paths), and not the "number" of "operations" (paths * http methods).
 
-* Only the "file-per-path" option is semantically correct with the OpenAPI Specification 3.0.2.  However, Redocly's openapi-cli will build valid bundles for any of the other options too.
+* Only the "file-per-path" option is semantically correct with the OpenAPI Specification 3.1.0.  However, Redocly's openapi-cli will build valid bundles for any of the other options too.
 
 
 #### Drawbacks


### PR DESCRIPTION
Summary
- Update the starter's OpenAPI Specification links from 3.0.2 to 3.1.0.
- Update component README anchors to the OpenAPI 3.1.0 heading format.

Reproduction
- The starter uses `openapi: 3.1.0` in `openapi/openapi.yaml`.
- Before this change, the description and component docs still linked to OpenAPI 3.0.2 documentation.

Root cause
- The starter spec was upgraded to OpenAPI 3.1.0, but a few documentation links and one paths README reference still pointed at 3.0.2.

Changes
- Point `openapi/openapi.yaml` to the OpenAPI 3.1.0 spec document.
- Point reusable component object links to OpenAPI 3.1.0 anchors.
- Update the paths README wording from OpenAPI Specification 3.0.2 to 3.1.0.

Tests
- `npm test`
- `git diff --check`
- Verified the referenced OpenAPI 3.1.0 headings exist in `versions/3.1.0.md`.

Screenshots/Logs
- `redocly lint` validates `openapi/openapi.yaml` successfully.
- Local Node emitted an engine warning because this machine has Node v22.2.0 and `@redocly/cli@2.31.4` expects `>=22.12.0 || >=20.19.0 <21.0.0`, but lint still completed successfully.

Fixes #116
