### PR TITLE
docs(other): fix the description of the Before parameter

### DIFF
--- a/openapi/components/parameters/Before.yaml
+++ b/openapi/components/parameters/Before.yaml
@@ -2,6 +2,6 @@ name: before
 in: query
 required: false
 description: |
-  Use the `startCursor` as a value for the `before` parameter to get the next page.
+  Use the `startCursor` as a value for the `before` parameter to get the previous page.
 schema:
   type: string


### PR DESCRIPTION
## What/Why/How?

Fixes the description of the `Before` parameter and brings it in line with description in `cafe-api` repo.

## Reference

Closes https://github.com/Redocly/redocly/issues/24594

## Testing

## Screenshots (optional)

## Check yourself

- [x] Code is linted
- [x] Tested
- [x] All new/updated code is covered with tests

## Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines
